### PR TITLE
Litellm fix missing x goog api key for cloudflare ai gateway

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1411,7 +1411,12 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         default_headers = {
             "Content-Type": "application/json",
         }
-        if api_key is not None:
+        if api_base is None and "api_base" in litellm_params:
+            api_base = litellm_params["api_base"]
+
+        if api_base is not None and "cloudflare" in api_base:
+            default_headers["x-goog-api-key"] = api_key
+        elif api_key is not None:
             default_headers["Authorization"] = f"Bearer {api_key}"
         if headers is not None:
             default_headers.update(headers)


### PR DESCRIPTION
## Title

Litellm fix missing x goog api key for cloudflare ai gateway

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


